### PR TITLE
Remove duplicate logging to console.

### DIFF
--- a/src/main/java/org/monstercraft/irc/plugin/util/ColorUtils.java
+++ b/src/main/java/org/monstercraft/irc/plugin/util/ColorUtils.java
@@ -99,7 +99,6 @@ public enum ColorUtils {
 			msg = ChatColor.stripColor(msg);
 		}
 		msg = resolve(msg.replace(WHITE.getIRCColor(), NORMAL.getIRCColor()));
-		IRC.log(ChatColor.stripColor(msg));
 		return msg;
 	}
 
@@ -116,11 +115,11 @@ public enum ColorUtils {
 	}
 
 	private static String replace(String input) {
-		return input.replace("&", "§");
+		return input.replace("&", "ï¿½");
 	}
 
 	private static String resolve(String input) {
-		return input.replace("§", "&");
+		return input.replace("ï¿½", "&");
 	}
 
 	private final String IRCColor;


### PR DESCRIPTION
This commit fixes the issue of logging normal chat messages twice to the console. Not only does it log the message twice, but even logging once is un-needed as normal chat gets logged to console anyway. IRC ---> Console logging still works fine however.
